### PR TITLE
Add support for CMake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ install.history
 amd64*
 Linux*
 *.pyc
+build
+install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,149 @@
+cmake_minimum_required(VERSION 2.8)
+message(STATUS "cmake version ${CMAKE_VERSION}")
+# Enforce an out-of-source builds before anything else
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+    message(STATUS "This software requires an out-of-source build.")
+    message(STATUS "Please remove these files from ${CMAKE_BINARY_DIR} first:")
+    message(STATUS "CMakeCache.txt")
+    message(STATUS "CMakeFiles")
+    message(STATUS "Once these files are removed, create a separate directory")
+    message(STATUS "and run CMake from there")
+    message(FATAL_ERROR "in-source build detected")
+endif()
+
+# Define project
+project(SNiPER)
+string(TOLOWER "${PROJECT_NAME}" ${PROJECT_NAME}_TOLOW)
+set(${PROJECT_NAME}_VERSION_MAJOR 1)
+set(${PROJECT_NAME}_VERSION_MINOR 1)
+set(${PROJECT_NAME}_VERSION_PATCH )
+set(${PROJECT_NAME}_VERSION 
+  ${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH})
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+
+# ... and configuration options
+option(DEBUG      "Turn debug options on" OFF)
+
+# Also https://cmake.org/Wiki/CMake:How_To_Write_Platform_Checks
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+else()
+    message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+endif()
+
+# check headers
+include(CheckIncludeFiles)
+check_include_files(unistd.h HAVE_UNISTD_H)
+check_include_files(time.h   HAVE_TIME_H)
+check_include_files(dlfcn.h  HAVE_DLFCN_H)
+# check functions
+# check libraries
+# check packages
+#include(RequiredPackages)
+find_package(UnixCommands)
+find_package(Git)
+find_package(PythonLibs 2.7)
+if(PYTHONLIBS_FOUND)
+  find_package(PythonInterp ${PYTHONLIBS_VERSION_STRING})
+endif()
+find_package(ROOT 5.18)
+set(Boost_USE_MULTITHREADED OFF)
+find_package(Boost 1.53 REQUIRED COMPONENTS python)
+
+# now check version information
+if(GIT_FOUND)
+
+  # closest tag
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --abbrev=0 --tags
+    OUTPUT_VARIABLE ${PROJECT_NAME}_GIT_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # it also codes the last package version on this branch
+  string(REGEX REPLACE "^v" "" ${PROJECT_NAME}_GIT_VERSION "${${PROJECT_NAME}_GIT_TAG}")
+  if("${${PROJECT_NAME}_VERSION_PATCH}" STREQUAL "dev")
+    if (NOT ${${PROJECT_NAME}_VERSION} VERSION_GREATER "${${PROJECT_NAME}_GIT_VERSION}")
+      message(WARNING "Project version mismatch: cmake=${${PROJECT_NAME}_VERSION} git=${${PROJECT_NAME}_GIT_VERSION}")
+    endif()
+  else()
+    if (NOT ${${PROJECT_NAME}_VERSION} VERSION_EQUAL "${${PROJECT_NAME}_GIT_VERSION}")
+      message(WARNING "Project version mismatch: cmake=${${PROJECT_NAME}_VERSION} git=${${PROJECT_NAME}_GIT_VERSION}")
+    endif()
+  endif()
+
+  # compact form for easy understanding of the current position of HEAD
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags HEAD
+    OUTPUT_VARIABLE ${PROJECT_NAME}_GIT_CID
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # calculate number of commits from the beginning
+  #  - something like SNV revision number
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} log --oneline HEAD
+    OUTPUT_VARIABLE tmp)
+  string(REGEX MATCHALL "[^\n]+\n" tmp "${tmp}")
+  list(LENGTH tmp tmp)
+  set(${PROJECT_NAME}_GIT_REV "r${tmp}")
+
+  # Do we have any modifications since last commit
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} status --short --untracked-files=no
+    OUTPUT_VARIABLE tmp)
+  if(NOT "${tmp}" STREQUAL "")
+    set(${PROJECT_NAME}_GIT_TAG "${${PROJECT_NAME}_GIT_TAG}-M")
+    set(${PROJECT_NAME}_GIT_CID "${${PROJECT_NAME}_GIT_CID}-M")
+  endif()
+
+  unset(tmp)
+
+endif()
+
+#
+#add_definitions(-DHAVE_CONFIG_H)
+include_directories(${Boost_INCLUDE_DIRS})
+if(ROOT_FOUND)
+  add_definitions(-DHAVE_ROOT)
+  include_directories(${ROOT_INCLUDE_DIRS})
+endif()
+if(PYTHONLIBS_FOUND)
+  add_definitions(-DHAVE_PYTHON)
+  include_directories(${PYTHON_INCLUDE_DIR})
+endif()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  add_definitions(-DLINUX)
+  set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib")
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--enable-new-dtags")
+endif()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # APPLE is in around
+  add_definitions(-DDARWIN)
+  set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  if(POLICY CMP0042)
+    cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
+  endif()
+  execute_process(COMMAND hostname OUTPUT_VARIABLE tmp OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(ENV{HOSTNAME} ${tmp})
+  unset(tmp)
+endif()
+if(WIN32)
+  add_definitions(-DWIN32)
+endif()
+if(DEBUG)
+  set(CMAKE_VERBOSE_MAKEFILE ON)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb")
+endif()
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--as-needed -Wl,--no-undefined")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--export-dynamic")
+
+#
+# build targets
+set(subdirs SniperKernel SniperUtil SniperSvc Examples)
+set(modlist)
+foreach(dir ${subdirs})
+  add_subdirectory(${dir})
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ string(TOLOWER "${PROJECT_NAME}" ${PROJECT_NAME}_TOLOW)
 set(${PROJECT_NAME}_VERSION_MAJOR 1)
 set(${PROJECT_NAME}_VERSION_MINOR 1)
 set(${PROJECT_NAME}_VERSION_PATCH )
-set(${PROJECT_NAME}_VERSION 
+string(REGEX REPLACE "\\.+$" "" ${PROJECT_NAME}_VERSION 
   ${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH})
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
@@ -140,6 +140,9 @@ endif()
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--as-needed -Wl,--no-undefined")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--export-dynamic")
 set(datadir "share/sniper")
+string(TIMESTAMP CONFIG_DATE)
+set(CONFIG_DATE ${CONFIG_DATE} CACHE INTERNAL "Date when build was made")
+set(CONFIG_USER $ENV{USER} CACHE INTERNAL "Name who did the build")
 
 #
 # build targets
@@ -150,9 +153,12 @@ set(modlist)
 foreach(dir ${subdirs})
   add_subdirectory(${dir})
 endforeach()
+# config is after subdirs since we need filename of SniperKernel library
+configure_file("${PROJECT_SOURCE_DIR}/${${PROJECT_NAME}_TOLOW}-config.in" "${PROJECT_BINARY_DIR}/${${PROJECT_NAME}_TOLOW}-config" @ONLY)
 
 #
 # install
 install(FILES setup.sh DESTINATION .)
+install(PROGRAMS "${PROJECT_BINARY_DIR}/${${PROJECT_NAME}_TOLOW}-config" DESTINATION bin)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cmt DESTINATION ${datadir})
 install(DIRECTORY SniperPolicy/cmt/fragments DESTINATION ${datadir}/SniperKernel/cmt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,9 +139,12 @@ if(DEBUG)
 endif()
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--as-needed -Wl,--no-undefined")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--export-dynamic")
+set(datadir "share/sniper")
 
 #
 # build targets
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmt/project.cmt "project sniper\n\nuse ExternalInterface\n\nbuild_strategy with_installarea\nsetup_strategy no_root\nsetup_strategy no_config\nstructure_strategy without_version_directory\n")
+file(COPY cmt/version.cmt DESTINATION cmt)
 set(subdirs SniperKernel SniperUtil SniperSvc Examples)
 set(modlist)
 foreach(dir ${subdirs})
@@ -150,5 +153,6 @@ endforeach()
 
 #
 # install
-file(GLOB setup setup.sh)
-install(FILES ${setup} DESTINATION .)
+install(FILES setup.sh DESTINATION .)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cmt DESTINATION ${datadir})
+install(DIRECTORY SniperPolicy/cmt/fragments DESTINATION ${datadir}/SniperKernel/cmt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,3 +147,8 @@ set(modlist)
 foreach(dir ${subdirs})
   add_subdirectory(${dir})
 endforeach()
+
+#
+# install
+file(GLOB setup setup.sh)
+install(FILES ${setup} DESTINATION .)

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+# Define project
+#project(modules)
+
+#
+file(GLOB dirlist *)
+foreach(file ${dirlist})
+  if(IS_DIRECTORY ${file})
+    add_subdirectory(${file})
+  endif()
+endforeach()
+#set(modlist ${modlist} PARENT_SCOPE)

--- a/Examples/DummyAlg/CMakeLists.txt
+++ b/Examples/DummyAlg/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 2.8)
+
+if(ROOT_FOUND)
+# Define project
+#project(DummyAlg)
+
+#
+# build
+include_directories(${PROJECT_SOURCE_DIR}/SniperKernel)
+include_directories(${PROJECT_SOURCE_DIR}/SniperSvc/RootWriter)
+file(GLOB sources src/*.cc)
+add_library(DummyAlg SHARED ${sources})
+target_link_libraries(DummyAlg SniperKernel RootWriter)
+
+# install
+install(TARGETS DummyAlg DESTINATION lib)
+file(GLOB python python/DummyAlg/*.py share/*.py)
+install(FILES ${python} DESTINATION python/DummyAlg)
+endif()

--- a/Examples/HelloWorld/CMakeLists.txt
+++ b/Examples/HelloWorld/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8)
+
+# Define project
+#project(HelloWorld)
+
+#
+# build
+include_directories(${PROJECT_SOURCE_DIR}/SniperKernel)
+file(GLOB sources src/*.cc)
+add_library(HelloWorld SHARED ${sources})
+target_link_libraries(HelloWorld SniperKernel)
+
+# install
+install(TARGETS HelloWorld DESTINATION lib)
+file(GLOB python python/HelloWorld/*.py share/*.py)
+install(FILES ${python} DESTINATION python/HelloWorld)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,70 @@
 # SNiPER
 
-SNiPER is a general purpose software framework for high energy physics data processing.
+The SNiPER is a open-source general purpose software framework for High Energy Physics data processing. It is dedicated for needs of rare-process search experiments, such as neutrino interactions, dark matter, double beta and other.
 
-More to be added...
+For more info please visit [the SNiPER home at GitHub](https://github.com/SNiPER-Framework).
+
+## Prerequisities
+
+Required packages:
+* CMT (v1r26 or later) - configuration management environment, main build system;
+* Compiler with C++11 support (GCC 4.8 or LLVM 3.4 or other);
+* Boost (1.53 or later, with Boost.Python) - portable C++ source libraries, used for interface with python scripts;
+* Python (2.7 or later) - interpreted, interactive, object-oriented programming language, used as main script engine for SNiPER modules.
+
+Optional software:
+* git (1.8 or later) - needed to get source code with repository;
+* cmake (2.8 or later) - alternative build system;
+* ROOT (5.18 or later) - needed for ROOT file I/O;
+* Intel TBB - for parallel computing.
+
+Note that in RHEL6 system (and derivatives) an old GCC 4.4.7 is used. To enable C++11 features, we recommend to use [devtoolset](http://linux.web.cern.ch/linux/devtoolset/) packages, where GCC 4.8 or better are available.
+
+## Build
+
+### Using CMT
+
+You need installed and working CMT environment. Also you'll need external packages Boost, Python (and ROOT) available under Externals/.
+
+Get the source gode using `git clone https://github.com/SNiPER-Framework/sniper.git` or downloading a [ZIP file](https://github.com/SNiPER-Framework/sniper/archive/master.zip) from GitHub and extracting it.
+
+Add source code directory to CMT path:
+
+```
+$ cd sniper
+$ export CMTPROJECTPATH=`pwd`:$CMTPROJECTPATH
+```
+
+Actually build SNiPER:
+
+```
+$ cd SniperRelease/cmt
+$ cmt br cmt config
+$ source setup.sh
+$ cmt br cmt make
+```
+
+### Using CMake
+
+Get the source gode using `git clone https://github.com/SNiPER-Framework/sniper.git` or downloading a [ZIP file](https://github.com/SNiPER-Framework/sniper/archive/master.zip) from GitHub and extracting it.
+
+Make build directory and change to it:
+
+```
+$ mkdir build && cd build
+```
+
+Run CMake to configure your build. By default it installs to `/usr/local`:
+
+```
+$ cmake -DCMAKE_INSTALL_REFIX=<install_dir> ..
+```
+
+Then build and install result:
+
+```
+$ make
+$ make install
+```
+
+Your build is now installed to the directory you provided to CMake, shell script `setup.sh` will help you to set the required environment.

--- a/SniperKernel/CMakeLists.txt
+++ b/SniperKernel/CMakeLists.txt
@@ -15,9 +15,43 @@ file(GLOB sources src/binding/*.cc)
 add_library(SniperPython SHARED ${sources})
 target_link_libraries(SniperPython SniperKernel)
 
+file(COPY cmt/version.cmt DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/cmt)
+set(req_head "
+package SniperKernel
+
+macro SniperKernel_home \"${CMAKE_INSTALL_PREFIX}\"
+macro SniperKernel_root \"$(SniperKernel_home)/share/sniper/SniperKernel\"
+
+macro_remove    cppflags        \"-ansi -pedantic \"
+macro_prepend   cppflags        \"-std=c++11 -fPIC \"
+
+#include_path none
+include_dirs \"$(SniperKernel_home)/include\"
+include_dirs \"${Boost_INCLUDE_DIR}\"
+include_dirs \"${PYTHON_INCLUDE_DIR}\"
+
+#macro SniperKernel_cppflags \"-std=c++11 -fPIC \"
+macro SniperKernel_linkopts \"-fPIC -Wl,--as-needed -Wl,--no-undefined -L$(SniperKernel_home)/lib -lSniperKernel ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARY} \"
+
+path_prepend PYTHONPATH \"$(SniperKernel_home)/python:$(SniperKernel_home)/lib\"
+path_prepend LD_LIBRARY_PATH \"$(SniperKernel_home)/lib\"
+
+#
+# from SniperPolicy
+#
+")
+file(READ ${PROJECT_SOURCE_DIR}/SniperPolicy/cmt/requirements _rules)
+string(FIND "${_rules}" "pattern" _offset)
+string(SUBSTRING "${_rules}" "${_offset}" "-1" _rules)
+string(REPLACE "SniperPolicy_" "SniperKernel_" req_rules "${_rules}")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmt/requirements "${req_head}${req_rules}")
+unset(_rules)
+unset(_offset)
+
 # install
 install(TARGETS SniperKernel SniperPython DESTINATION lib)
 file(GLOB headers SniperKernel/*.h)
 install(FILES ${headers} DESTINATION include/SniperKernel)
 file(GLOB python python/Sniper/*.py)
 install(FILES ${python} DESTINATION python/Sniper)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cmt DESTINATION ${datadir}/SniperKernel)

--- a/SniperKernel/CMakeLists.txt
+++ b/SniperKernel/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 2.8)
+
+# Define project
+#project(SniperKernel)
+
+#
+# build
+include_directories(${PROJECT_SOURCE_DIR}/SniperKernel)
+file(GLOB sources src/*.cc)
+add_library(SniperKernel SHARED ${sources})
+target_link_libraries(SniperKernel dl ${PYTHON_LIBRARY} boost_python)
+
+include_directories(${PROJECT_SOURCE_DIR}/SniperKernel/src)
+file(GLOB sources src/binding/*.cc)
+add_library(SniperPython SHARED ${sources})
+target_link_libraries(SniperPython SniperKernel)
+
+# install
+install(TARGETS SniperKernel SniperPython DESTINATION lib)
+file(GLOB headers SniperKernel/*.h)
+install(FILES ${headers} DESTINATION include/SniperKernel)
+file(GLOB python python/Sniper/*.py)
+install(FILES ${python} DESTINATION python/Sniper)

--- a/SniperKernel/CMakeLists.txt
+++ b/SniperKernel/CMakeLists.txt
@@ -15,6 +15,9 @@ file(GLOB sources src/binding/*.cc)
 add_library(SniperPython SHARED ${sources})
 target_link_libraries(SniperPython SniperKernel)
 
+get_target_property(_file SniperKernel LOCATION)
+get_filename_component(_file ${_file} NAME)
+set(SniperKernel_LIB_NAME ${_file} PARENT_SCOPE)
 file(COPY cmt/version.cmt DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/cmt)
 set(req_head "
 package SniperKernel
@@ -25,13 +28,13 @@ macro SniperKernel_root \"$(SniperKernel_home)/share/sniper/SniperKernel\"
 macro_remove    cppflags        \"-ansi -pedantic \"
 macro_prepend   cppflags        \"-std=c++11 -fPIC \"
 
-#include_path none
+include_path none
 include_dirs \"$(SniperKernel_home)/include\"
 include_dirs \"${Boost_INCLUDE_DIR}\"
 include_dirs \"${PYTHON_INCLUDE_DIR}\"
 
 #macro SniperKernel_cppflags \"-std=c++11 -fPIC \"
-macro SniperKernel_linkopts \"-fPIC -Wl,--as-needed -Wl,--no-undefined -L$(SniperKernel_home)/lib -lSniperKernel ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARY} \"
+macro SniperKernel_linkopts \"-fPIC -Wl,--as-needed -Wl,--no-undefined $(SniperKernel_home)/lib/${_file} ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARY} \"
 
 path_prepend PYTHONPATH \"$(SniperKernel_home)/python:$(SniperKernel_home)/lib\"
 path_prepend LD_LIBRARY_PATH \"$(SniperKernel_home)/lib\"
@@ -45,6 +48,7 @@ string(FIND "${_rules}" "pattern" _offset)
 string(SUBSTRING "${_rules}" "${_offset}" "-1" _rules)
 string(REPLACE "SniperPolicy_" "SniperKernel_" req_rules "${_rules}")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmt/requirements "${req_head}${req_rules}")
+unset(_file)
 unset(_rules)
 unset(_offset)
 

--- a/SniperSvc/CMakeLists.txt
+++ b/SniperSvc/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+# Define project
+#project(modules)
+
+#
+file(GLOB dirlist *)
+foreach(file ${dirlist})
+  if(IS_DIRECTORY ${file})
+    add_subdirectory(${file})
+  endif()
+endforeach()
+#set(modlist ${modlist} PARENT_SCOPE)

--- a/SniperSvc/RootWriter/CMakeLists.txt
+++ b/SniperSvc/RootWriter/CMakeLists.txt
@@ -10,13 +10,24 @@ include_directories(${PROJECT_SOURCE_DIR}/SniperKernel)
 include_directories(${PROJECT_SOURCE_DIR}/SniperSvc/RootWriter)
 file(GLOB sources src/*.cc binding/RootWriterBinding.cc)
 add_library(RootWriter SHARED ${sources})
-set(ROOT_PyROOT_LIBRARY /usr/lib64/root/libPyROOT.so)
+set(ROOT_PyROOT_LIBRARY ${ROOT_LIBRARY_DIR}/libPyROOT.so)
 target_link_libraries(RootWriter SniperKernel ${ROOT_Core_LIBRARY} ${ROOT_RIO_LIBRARY} ${ROOT_Tree_LIBRARY} ${ROOT_PyROOT_LIBRARY} ${PYTHON_LIBRARY} boost_python)
+file(COPY cmt/version.cmt DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/cmt)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmt/requirements "
+package RootWriter
+
+use SniperKernel v*
+
+macro_append RootWriter_cppflags \"`root-config --cflags`\"
+macro_append RootWriter_cppflags \" -Wno-long-long \"
+#macro_append RootWriter_linkopts \"`root-config --libs`\"
+")
 
 # install
 install(TARGETS RootWriter DESTINATION lib)
-file(GLOB headers RootWriter/*.h)
-install(FILES ${headers} DESTINATION include/RootWriter)
+install(FILES RootWriter/RootWriter.h DESTINATION include/RootWriter)
 file(GLOB python python/RootWriter/*.py)
 install(FILES ${python} DESTINATION python/RootWriter)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cmt DESTINATION ${datadir}/RootWriter)
+
 endif()

--- a/SniperSvc/RootWriter/CMakeLists.txt
+++ b/SniperSvc/RootWriter/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 2.8)
+
+if(ROOT_FOUND)
+# Define project
+#project(RootWriter)
+
+#
+# build
+include_directories(${PROJECT_SOURCE_DIR}/SniperKernel)
+include_directories(${PROJECT_SOURCE_DIR}/SniperSvc/RootWriter)
+file(GLOB sources src/*.cc binding/RootWriterBinding.cc)
+add_library(RootWriter SHARED ${sources})
+set(ROOT_PyROOT_LIBRARY /usr/lib64/root/libPyROOT.so)
+target_link_libraries(RootWriter SniperKernel ${ROOT_Core_LIBRARY} ${ROOT_RIO_LIBRARY} ${ROOT_Tree_LIBRARY} ${ROOT_PyROOT_LIBRARY} ${PYTHON_LIBRARY} boost_python)
+
+# install
+install(TARGETS RootWriter DESTINATION lib)
+file(GLOB headers RootWriter/*.h)
+install(FILES ${headers} DESTINATION include/RootWriter)
+file(GLOB python python/RootWriter/*.py)
+install(FILES ${python} DESTINATION python/RootWriter)
+endif()

--- a/SniperUtil/CMakeLists.txt
+++ b/SniperUtil/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+# Define project
+#project(modules)
+
+#
+file(GLOB dirlist *)
+foreach(file ${dirlist})
+  if(IS_DIRECTORY ${file})
+    add_subdirectory(${file})
+  endif()
+endforeach()
+#set(modlist ${modlist} PARENT_SCOPE)

--- a/SniperUtil/DataBuffer/CMakeLists.txt
+++ b/SniperUtil/DataBuffer/CMakeLists.txt
@@ -5,7 +5,9 @@ cmake_minimum_required(VERSION 2.8)
 
 #
 # build
+file(COPY cmt/version.cmt DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/cmt)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmt/requirements "package DataBuffer\n\nuse SniperKernel v*\n")
 
 # install
-file(GLOB headers DataBuffer/*.h)
-install(FILES ${headers} DESTINATION include/DataBuffer)
+install(FILES DataBuffer/DataBuffer.h DESTINATION include/DataBuffer)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cmt DESTINATION ${datadir}/DataBuffer)

--- a/SniperUtil/DataBuffer/CMakeLists.txt
+++ b/SniperUtil/DataBuffer/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8)
+
+# Define project
+#project(DataBuffer)
+
+#
+# build
+
+# install
+file(GLOB headers DataBuffer/*.h)
+install(FILES ${headers} DESTINATION include/DataBuffer)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+filename=`readlink -f "${BASH_SOURCE[0]}"`
+basedir=`dirname "${filename}"`
+
+export PYTHONPATH="$basedir/python:$basedir/lib${PYTHONPATH:+:${PYTHONPATH}}"
+export LD_LIBRARY_PATH="$basedir/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"

--- a/setup.sh
+++ b/setup.sh
@@ -3,5 +3,6 @@
 filename=`readlink -f "${BASH_SOURCE[0]}"`
 basedir=`dirname "${filename}"`
 
+export CMTPROJECTPATH="$basedir/share${CMTPROJECTPATH:+:${CMTPROJECTPATH}}"
 export PYTHONPATH="$basedir/python:$basedir/lib${PYTHONPATH:+:${PYTHONPATH}}"
 export LD_LIBRARY_PATH="$basedir/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"

--- a/sniper-config.in
+++ b/sniper-config.in
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+if [ "x$use_relative_path" != "xyes" ]; then
+  prefix="@CMAKE_INSTALL_PREFIX@"
+  exec_prefix="$prefix/bin"
+  includedir="$prefix/include"
+  libdir="$prefix/lib"
+else
+  prefix=`echo $0 | sed -e 's|/[^/]*$||; s|^[^/]*$|.|'`
+  exec_prefix=$prefix
+  includedir=$prefix/../include
+  libdir=$prefix/../lib
+fi
+
+usage()
+{
+    cat <<EOF
+Usage: sniper-config [OPTION]
+
+Available values for OPTION include:
+
+  --help             display this help and exit
+  --prefix           install prefix
+  --version          version information
+  --features         list of all supported features
+  --build            show build id
+  --incdir           directory with header files
+  --cflags           compile flags and header paths
+  --libdir           directory with library files
+  --libs             link flags and libraries
+
+EOF
+
+    exit $1
+}
+
+if test $# -eq 0; then
+    echo "Usage: sniper-config [--help] [--prefix] [--version] [--features] [--build] [--incdir] [--cflags] [--libdir] [--libs]"
+    exit 1;
+fi
+
+while test $# -gt 0; do
+    case "$1" in
+    # this deals with options in the style
+    # --option=value and extracts the value part
+    # [not currently used]
+    -*=*) value=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
+    *) value= ;;
+    esac
+
+    case "$1" in
+
+    --help)
+        usage 0
+        ;;
+
+    --prefix)
+        echo "$prefix"
+        ;;
+
+    --version)
+        echo "@SNiPER_VERSION@"
+        exit 0
+        ;;
+
+    --feature|--features)
+        for feature in RootWriter ""; do
+            test -n "$feature" && echo "$feature"
+        done
+        ;;
+
+    --build)
+        echo "@PROJECT_NAME@ v@SNiPER_VERSION@ built by @CONFIG_USER@ at @CONFIG_DATE@"
+        exit 0
+        ;;
+
+    --incdir)
+        echo "$includedir"
+        ;;
+
+    --cflags)
+        echo "-std=c++11 -fPIC -I$includedir -I@Boost_INCLUDE_DIR@ -I@PYTHON_INCLUDE_DIR@"
+        ;;
+
+    --libdir)
+        echo "$libdir"
+        ;;
+
+    --libs)
+        echo "-fPIC -Wl,--as-needed -Wl,--no-undefined $libdir/@SniperKernel_LIB_NAME@ @Boost_PYTHON_LIBRARY@ @PYTHON_LIBRARY@"
+        ;;
+
+    *)
+        echo "unknown option: $1"
+        usage 1
+        ;;
+    esac
+    shift
+done
+
+exit 0
+


### PR DESCRIPTION
The purpose of this work is to change build system of SNiPER from CMT to CMake. 

This is important since many of new derived projects don't use CMT system in their environment, also CMT becomes poorly maintained and obsolete. CMake looks as a good alternative, because it is cross-platform and very configurable and widely used.

This PR is a first stage and it allows to build SNiPER using CMake. Installed package contain `sniper-config` binary for use by any build system. Also an old CMT package environment is provided, so derived projects can continue to use it with CMT builds after minor changes in corresponding `requirement` files.