### PR TITLE
Fix compiler warnings about shadowing of variables.

### DIFF
--- a/SniperKernel/SniperKernel/DLElement.h
+++ b/SniperKernel/SniperKernel/DLElement.h
@@ -47,7 +47,7 @@ class DLElement : public NamedElement
         Task* getRoot();
 
         // set the tag
-        void setTag(const std::string& tag) { m_tag = tag; }
+        void setTag(const std::string& tag_) { m_tag = tag_; }
 
         // set the parent (Task) pointer
         void setParent(Task* parent);

--- a/SniperKernel/SniperKernel/Property.h
+++ b/SniperKernel/SniperKernel/Property.h
@@ -66,8 +66,8 @@ class SniperProperty : public Property
 {
     public :
 
-        SniperProperty(const std::string& key, T& var)
-            : Property(key), m_var(var) {}
+        SniperProperty(const std::string& key_, T& var_)
+            : Property(key_), m_var(var_) {}
 
         bool set(bp::object& var)
         {
@@ -96,8 +96,8 @@ class SniperProperty<std::vector<T> > : public Property
 {
     public :
 
-        SniperProperty(const std::string& key, std::vector<T>& var)
-            : Property(key), m_var(var) {}
+        SniperProperty(const std::string& key_, std::vector<T>& var_)
+            : Property(key_), m_var(var_) {}
 
         bool set(bp::object& var) {
             m_var.clear();
@@ -138,8 +138,8 @@ class SniperProperty<std::map<K, V> > : public Property
 {
     public:
 
-        SniperProperty(const std::string& key, std::map<K, V>& var)
-            : Property(key), m_var(var) {}
+        SniperProperty(const std::string& key_, std::map<K, V>& var_)
+            : Property(key_), m_var(var_) {}
 
         bool set(bp::object& var) {
             m_var.clear();

--- a/SniperKernel/src/DleSupervisor.cc
+++ b/SniperKernel/src/DleSupervisor.cc
@@ -27,8 +27,8 @@ DleSupervisor::DleSupervisor(const std::string& name)
 {
 }
 
-DleSupervisor::DleSupervisor(const std::string& scope, const std::string& name)
-    : NamedElement(scope, name)
+DleSupervisor::DleSupervisor(const std::string& scope_, const std::string& name_)
+    : NamedElement(scope_, name_)
 {
 }
 

--- a/SniperKernel/src/NamedElement.cc
+++ b/SniperKernel/src/NamedElement.cc
@@ -25,8 +25,8 @@ NamedElement::NamedElement(const std::string& name)
     m_logLevel = SniperLog::logLevel();
 }
 
-NamedElement::NamedElement(const std::string& scope, const std::string& name)
-    : m_scope(scope), m_name(name)
+NamedElement::NamedElement(const std::string& scope_, const std::string& name_)
+    : m_scope(scope_), m_name(name_)
 {
     m_logLevel = SniperLog::logLevel();
 }

--- a/SniperKernel/src/NonUserIf/TaskProperty.h
+++ b/SniperKernel/src/NonUserIf/TaskProperty.h
@@ -28,21 +28,21 @@ class TaskProperty : public SniperProperty<std::vector<std::string> >
 
         typedef SniperProperty<std::vector<std::string> > BaseType;
 
-        TaskProperty(const std::string&key, Task* domain)
-            : BaseType(key, m_names), m_domain(domain)
+        TaskProperty(const std::string& key_, Task* domain_)
+            : BaseType(key_, m_names), m_domain(domain_)
         {
-            if ( key == "algs") {
+            if ( key_ == "algs") {
                 pclear  = &Task::clearAlgs;
                 pcreate = &TaskProperty::createAlg;
                 padd    = &TaskProperty::addAlg;
             }
-            else if ( key == "svcs" ) {
+            else if ( key_ == "svcs" ) {
                 pclear  = &Task::clearSvcs;
                 pcreate = &TaskProperty::createSvc;
                 padd    = &TaskProperty::addSvc;
             }
             else {
-                throw ContextMsgException( key + " : invalid TaskProperty Key");
+                throw ContextMsgException( key_ + " : invalid TaskProperty Key");
             }
         }
 

--- a/SniperKernel/src/Property.cc
+++ b/SniperKernel/src/Property.cc
@@ -18,8 +18,8 @@
 
 #include "SniperKernel/Property.h"
 
-Property::Property(const std::string& key)
-    : m_key(key)
+Property::Property(const std::string& key_)
+    : m_key(key_)
 {
 }
 

--- a/SniperKernel/src/PropertyMgr.cc
+++ b/SniperKernel/src/PropertyMgr.cc
@@ -41,12 +41,12 @@ Property* PropertyMgr::property(const std::string& key)
     throw ContextMsgException(key + " : invalid Property Key");
 }
 
-bool PropertyMgr::addProperty(Property* property)
+bool PropertyMgr::addProperty(Property* property_)
 {
-    std::string key = property->key();
+    std::string key = property_->key();
     std::map<std::string, Property*>::iterator it = m_dict.find(key);
     if ( it == m_dict.end() ) {
-        m_dict[key] = property;
+        m_dict[key] = property_;
         return true;
     }
     throw ContextMsgException(key + " : duplicated Property Key");

--- a/SniperKernel/src/Task.cc
+++ b/SniperKernel/src/Task.cc
@@ -180,9 +180,9 @@ void Task::setLogLevel(int level)
     }
 }
 
-void Task::setEvtMax(int evtMax)
+void Task::setEvtMax(int evtMax_)
 {
-    m_evtMax = evtMax;
+    m_evtMax = evtMax_;
     m_limited = (m_evtMax >= 0);
 }
 


### PR DESCRIPTION
Defined variables can 'shadow' variables of the same name from outer scopes. Most compiler offer checks for that and can print warnings, if asked. This is a very useful check, since problem can lead to tricky mistakes and undefined behaviour. Some compilers complain even if variable has the same name as a method of a class. Compiler clearly can distinguish these two cases, after deeper look, but we can deal with it too. Simple renaming works fine.

This PR fixes such warnings in sniper. The most annoying cases are Property.h and DLElement.h, which can issue a warning at every source file, where included. No actual changes in code happens, only trivial change of names.