### PR TITLE
SniperPolicy/cmt: explicitly use python2.

### DIFF
--- a/SniperPolicy/cmt/fragments/install.py
+++ b/SniperPolicy/cmt/fragments/install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Script used to install files keeping track of the files that have
 been installed, so that at the next installation the file removed

--- a/SniperPolicy/cmt/requirements
+++ b/SniperPolicy/cmt/requirements
@@ -71,13 +71,13 @@ cmtpath_pattern_reverse \
          <project>_with_installarea&WIN32 ' "<path>\$(<project>_installarea_prefix)\include"' ; \
    include_dirs ${<project>_install_include} 
 
-macro install_command 'python $(SniperPolicy_root)/cmt/fragments/install.py -xCVS -x.svn -x*~ -x*.stamp --log=./install.history '
-macro uninstall_command 'python $(SniperPolicy_root)/cmt/fragments/install.py -u --log=./install.history '
+macro install_command 'python2 $(SniperPolicy_root)/cmt/fragments/install.py -xCVS -x.svn -x*~ -x*.stamp --log=./install.history '
+macro uninstall_command 'python2 $(SniperPolicy_root)/cmt/fragments/install.py -u --log=./install.history '
 
 macro remove_command "$(cmt_uninstallarea_command)"
 
-macro library_install_command "python $(SniperPolicy_root)/cmt/fragments/install.py -xCVS -x.svn -x*~ -x*.stamp -s --log=./install.history "
-macro cmt_installarea_command "python $(SniperPolicy_root)/cmt/fragments/install.py -xCVS -x.svn -x*~ -x*.stamp -s --log=./install.history "
+macro library_install_command "python2 $(SniperPolicy_root)/cmt/fragments/install.py -xCVS -x.svn -x*~ -x*.stamp -s --log=./install.history "
+macro cmt_installarea_command "python2 $(SniperPolicy_root)/cmt/fragments/install.py -xCVS -x.svn -x*~ -x*.stamp -s --log=./install.history "
 
 # setup python path
 


### PR DESCRIPTION
Python 2 will soon be end-of-life, some GNU/Linux distributions have
set /usr/bin/python default to Python 3.  To avoid ambiguity for the
future, call python2 explicitly.

This does not affect the CentOS 6 or 7 in use.

Bug: https://github.com/SNiPER-Framework/sniper/issues/13