### PR TITLE
SniperKernel/cmt/requirements: no need to link against SniperPython.

### DIFF
--- a/SniperKernel/cmt/requirements
+++ b/SniperKernel/cmt/requirements
@@ -10,6 +10,5 @@ library SniperKernel *.cc
 apply_pattern linker_library library=SniperKernel
 
 library SniperPython binding/*.cc
-apply_pattern linker_library library=SniperPython
 macro SniperPython_dependencies SniperKernel
 macro_append SniperPython_shlibflags " -lSniperKernel "


### PR DESCRIPTION
  User libraries do not need to link against SniperPython.

  By design, libSniperPython.so is loaded from Python context, no
  other dynamic libraries in the C/C++ context use symbols from
  libSniperPython.so.